### PR TITLE
refactor(retry): Refactor internals to final and private

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@
 #
 
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -19,8 +21,6 @@ on:
   push:
     branches:
       - 'master'
-  schedule:
-    - cron: '37 */8 * * *'
 
 env:
   COLUMNS: 120
@@ -34,7 +34,7 @@ jobs:
       JBZOO_COMPOSER_UPDATE_FLAGS: ${{ matrix.composer_flags }}
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
         coverage: [ xdebug, none ]
         composer_flags: [ "--prefer-lowest", "" ]
     steps:
@@ -65,7 +65,7 @@ jobs:
         run: make report-coveralls --no-print-directory || true
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: PHPUnit - ${{ matrix.php-version }} - ${{ matrix.coverage }}
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -99,7 +99,7 @@ jobs:
         run: make codestyle --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Linters - ${{ matrix.php-version }}
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -133,7 +133,7 @@ jobs:
         run: make report-all --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Reports - ${{ matrix.php-version }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JBZoo / Retry
 
-[![CI](https://github.com/JBZoo/Retry/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Retry/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Retry/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Retry?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Retry/coverage.svg)](https://shepherd.dev/github/JBZoo/Retry)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Retry/level.svg)](https://shepherd.dev/github/JBZoo/Retry)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/retry/badge)](https://www.codefactor.io/repository/github/jbzoo/retry/issues)    
+[![CI](https://github.com/JBZoo/Retry/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Retry/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Retry/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Retry?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Retry/coverage.svg)](https://shepherd.dev/github/JBZoo/Retry)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Retry/level.svg)](https://shepherd.dev/github/JBZoo/Retry)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/retry/badge)](https://www.codefactor.io/repository/github/jbzoo/retry/issues)
 [![Stable Version](https://poser.pugx.org/jbzoo/retry/version)](https://packagist.org/packages/jbzoo/retry/)    [![Total Downloads](https://poser.pugx.org/jbzoo/retry/downloads)](https://packagist.org/packages/jbzoo/retry/stats)    [![Dependents](https://poser.pugx.org/jbzoo/retry/dependents)](https://packagist.org/packages/jbzoo/retry/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/retry)](https://github.com/JBZoo/Retry/blob/master/LICENSE)
 
 
@@ -12,7 +12,7 @@
 
 Notes:
  * This is a fork. You can find the original project [here](https://github.com/stechstudio/backoff).
- * Now the codebase super strict, and it's covered with tests as much as possible. The original author is great, but the code was smelly :) It's sooo easy, and it took just one my evening... ;) 
+ * Now the codebase super strict, and it's covered with tests as much as possible. The original author is great, but the code was smelly :) It's sooo easy, and it took just one my evening... ;)
  * I don't like wording "backoff" in the code. Yeah, it's fun but... I believe "retry" is more obvious. Sorry :)
  * There is nothing wrong to use import instead of global namespace for function. Don't use old-school practices.
  * Static variables with default values are deprecated and disabled. See dump of thoughts below.
@@ -89,14 +89,7 @@ This is terrible practice! Explicit is better than implicit. ;)
  * Example #3. It's just an attempt to store variables in a global namespace. Do you see it?
 
 
-So the next variables are deprecated, and they don't influence anything.
-```php
-use JBZoo\Retry\Retry;
-
-Retry::$defaultMaxAttempts;
 Retry::$defaultStrategy;
-Retry::$defaultJitterEnabled;
-```
 
 Just use dependencies injection or so and don't warm your head.
 
@@ -286,5 +279,5 @@ MIT
 - [Mermaid-PHP](https://github.com/JBZoo/Mermaid-PHP) - Generate diagrams and flowcharts with the help of the mermaid script language.
 - [Utils](https://github.com/JBZoo/Utils) - Collection of useful PHP functions, mini-classes, and snippets for every day.
 - [Image](https://github.com/JBZoo/Image) - Package provides object-oriented way to manipulate with images as simple as possible.
-- [Data](https://github.com/JBZoo/Data) - Extended implementation of ArrayObject. Use files as config/array. 
+- [Data](https://github.com/JBZoo/Data) - Extended implementation of ArrayObject. Use files as config/array.
 - [SimpleTypes](https://github.com/JBZoo/SimpleTypes) - Converting any values and measures - money, weight, exchange rates, length, ...

--- a/composer.json
+++ b/composer.json
@@ -33,11 +33,11 @@
     "prefer-stable"     : true,
 
     "require"           : {
-        "php" : "^8.1"
+        "php" : "^8.2"
     },
 
     "require-dev"       : {
-        "jbzoo/toolbox-dev" : "^7.1"
+        "jbzoo/toolbox-dev" : "^7.2"
     },
 
     "replace"           : {

--- a/src/Retry.php
+++ b/src/Retry.php
@@ -16,13 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\Retry;
 
-use JBZoo\Retry\Strategies\AbstractStrategy;
 use JBZoo\Retry\Strategies\ConstantStrategy;
 use JBZoo\Retry\Strategies\ExponentialStrategy;
 use JBZoo\Retry\Strategies\LinearStrategy;
 use JBZoo\Retry\Strategies\PolynomialStrategy;
 
-class Retry
+final class Retry
 {
     // Fallback values and global defaults
     public const DEFAULT_MAX_ATTEMPTS   = 5;
@@ -36,58 +35,47 @@ class Retry
     public const STRATEGY_POLYNOMIAL  = 'polynomial';
     public const STRATEGY_EXPONENTIAL = 'exponential';
 
-    /** @deprecated See README.md "Changing defaults" */
-    public static int $defaultMaxAttempts = self::DEFAULT_MAX_ATTEMPTS;
-
-    /**
-     * @deprecated See README.md "Changing defaults"
-     */
-    public static AbstractStrategy|string $defaultStrategy = self::DEFAULT_STRATEGY;
-
-    /** @deprecated See README.md "Changing defaults" */
-    public static bool $defaultJitterEnabled = self::DEFAULT_JITTER_STATE;
-
     /**
      * This callable should take an 'attempt' integer, and return a wait time in milliseconds.
      * @var callable
      */
-    protected $strategy;
+    private $strategy;
 
-    protected array $strategies = [
+    private array $strategies = [
         self::STRATEGY_CONSTANT    => ConstantStrategy::class,
         self::STRATEGY_LINEAR      => LinearStrategy::class,
         self::STRATEGY_POLYNOMIAL  => PolynomialStrategy::class,
         self::STRATEGY_EXPONENTIAL => ExponentialStrategy::class,
     ];
 
-    protected int $maxAttempts;
+    private int $maxAttempts;
 
     /**
      * The max wait time you want to allow, regardless of what the strategy says.
      * @var null|int In milliseconds
      */
-    protected ?int $waitCap;
+    private ?int $waitCap;
 
-    protected bool $useJitter = false;
+    private bool $useJitter = false;
 
-    protected int $jitterPercent = self::DEFAULT_JITTER_PERCENT;
+    private int $jitterPercent = self::DEFAULT_JITTER_PERCENT;
 
-    protected int $jitterMinTime = 0;
+    private int $jitterMinTime = 0;
 
     /** @var array|non-empty-array<int,\Exception>|non-empty-array<int,\Throwable> */
-    protected array $exceptions = [];
+    private array $exceptions = [];
 
     /**
      * This will decide whether to retry or not.
      * @var callable
      */
-    protected $decider;
+    private $decider;
 
     /**
      * This receives any exceptions we encounter.
      * @var null|callable
      */
-    protected $errorHandler;
+    private $errorHandler;
 
     public function __construct(
         int $maxAttempts = self::DEFAULT_MAX_ATTEMPTS,
@@ -297,6 +285,11 @@ class Retry
         return $this->jitter($this->cap($waitTime));
     }
 
+    public function getExceptions(): array
+    {
+        return $this->exceptions;
+    }
+
     /**
      * Builds a callable strategy.
      *
@@ -304,7 +297,7 @@ class Retry
      *                        (or any other instance that has an __invoke method), a callback function, or
      *                        an integer (which we interpret to mean you want a ConstantStrategy)
      */
-    protected function buildStrategy(mixed $strategy): callable
+    private function buildStrategy(mixed $strategy): callable
     {
         if (\is_string($strategy) && \array_key_exists($strategy, $this->strategies)) {
             $result = new $this->strategies[$strategy]();
@@ -325,14 +318,14 @@ class Retry
         throw new \InvalidArgumentException("Invalid strategy: {$strategy}");
     }
 
-    protected function cap(int $waitTime): int
+    private function cap(int $waitTime): int
     {
         $waitCap = (int)$this->getWaitCap();
 
         return $waitCap > 0 ? \min($waitCap, $waitTime) : $waitTime;
     }
 
-    protected function jitter(int $waitTime): int
+    private function jitter(int $waitTime): int
     {
         if ($this->jitterEnabled()) {
             $minValue = $this->jitterMinTime;
@@ -351,15 +344,14 @@ class Retry
     /**
      * Gets a default decider that simply check exceptions and max-attempts.
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     * @psalm-suppress MissingClosureParamType
      */
-    protected static function getDefaultDecider(): \Closure
+    private static function getDefaultDecider(): \Closure
     {
         return static function (
             int $currentAttempt,
             int $maxAttempts,
             /** @phan-suppress-next-line PhanUnusedClosureParameter */
-            $result = null,
+            mixed $result = null,
             ?\Exception $exception = null,
         ): bool {
             if ($currentAttempt >= $maxAttempts && $exception !== null) {

--- a/src/Strategies/ConstantStrategy.php
+++ b/src/Strategies/ConstantStrategy.php
@@ -16,10 +16,10 @@ declare(strict_types=1);
 
 namespace JBZoo\Retry\Strategies;
 
-class ConstantStrategy extends AbstractStrategy
+final class ConstantStrategy extends AbstractStrategy
 {
     /**
-     * @phan-suppress PhanUnusedPublicMethodParameter
+     * @phan-suppress PhanUnusedPublicFinalMethodParameter
      */
     public function getWaitTime(int $attempt): int
     {

--- a/src/Strategies/Exception.php
+++ b/src/Strategies/Exception.php
@@ -16,6 +16,9 @@ declare(strict_types=1);
 
 namespace JBZoo\Retry\Strategies;
 
-class Exception extends \JBZoo\Retry\Exception
+/**
+ * @psalm-suppress UnusedClass
+ */
+final class Exception extends \JBZoo\Retry\Exception
 {
 }

--- a/src/Strategies/ExponentialStrategy.php
+++ b/src/Strategies/ExponentialStrategy.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\Retry\Strategies;
 
-class ExponentialStrategy extends AbstractStrategy
+final class ExponentialStrategy extends AbstractStrategy
 {
     public function getWaitTime(int $attempt): int
     {

--- a/src/Strategies/LinearStrategy.php
+++ b/src/Strategies/LinearStrategy.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\Retry\Strategies;
 
-class LinearStrategy extends AbstractStrategy
+final class LinearStrategy extends AbstractStrategy
 {
     public function getWaitTime(int $attempt): int
     {

--- a/src/Strategies/PolynomialStrategy.php
+++ b/src/Strategies/PolynomialStrategy.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\Retry\Strategies;
 
-class PolynomialStrategy extends AbstractStrategy
+final class PolynomialStrategy extends AbstractStrategy
 {
     protected const DEFAULT_DEGREE = 2;
 

--- a/src/aliases.php
+++ b/src/aliases.php
@@ -27,9 +27,8 @@ use function JBZoo\Retry\retry;
 if (!\function_exists('backoff')) {
     /**
      * @phan-suppress PhanParamTooFewUnpack
-     * @return mixed
      */
-    function backoff()
+    function backoff(): mixed
     {
         return retry(...\func_get_args());
     }

--- a/tests/RetryTest.php
+++ b/tests/RetryTest.php
@@ -54,26 +54,15 @@ class RetryTest extends PHPUnit
 
     public function testNotChangingStaticDefaults(): void
     {
-        Retry::$defaultMaxAttempts   = 15;
-        Retry::$defaultStrategy      = 'constant';
-        Retry::$defaultJitterEnabled = true;
-
         $retry = new Retry();
 
         isSame(Retry::DEFAULT_MAX_ATTEMPTS, $retry->getMaxAttempts());
         self::assertInstanceOf(PolynomialStrategy::class, $retry->getStrategy());
         isSame(Retry::DEFAULT_JITTER_STATE, $retry->jitterEnabled());
 
-        Retry::$defaultStrategy = new LinearStrategy(250);
-
         $retry = new Retry();
 
         self::assertInstanceOf(PolynomialStrategy::class, $retry->getStrategy());
-
-        // I don't care about put them back. They dont' work at all and deprecated.
-        // Retry::$defaultMaxAttempts = 5;
-        // Retry::$defaultStrategy = "polynomial";
-        // Retry::$defaultJitterEnabled = false;
     }
 
     public function testConstructorParams(): void


### PR DESCRIPTION
- Mark strategy classes and internal Exception as final to enforce immutability and clarify API boundary
- Convert many Retry properties and helper methods from protected to private and remove deprecated static defaults to tighten encapsulation
- Add getExceptions() and narrow visibility of buildStrategy/cap/jitter/getDefaultDecider
- Update backoff() return type to mixed and add phan/psalm suppress annotations for analyzers
- Bump PHP requirement to ^8.2 and toolbox-dev to ^7.2; update CI matrix to PHP 8.2-8.4, upgrade upload-artifact to v4, remove schedule cron, and set workflow contents read permission
- Apply minor README formatting fixes