### PR TITLE
8.0.0 — PHP 8.3+ floor & lock-step major

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,15 @@ permissions:
   contents: read
 
 on:
+  schedule:
+    - cron: '0 4 * * *'   # daily 04:00 UTC canary keepalive
   pull_request:
     branches:
       - "*"
   push:
     branches:
       - 'master'
+  workflow_dispatch: {}
 
 env:
   COLUMNS: 120
@@ -34,20 +37,20 @@ jobs:
       JBZOO_COMPOSER_UPDATE_FLAGS: ${{ matrix.composer_flags }}
     strategy:
       matrix:
-        php-version: [ 8.2, 8.3, 8.4 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
         coverage: [ xdebug, none ]
         composer_flags: [ "--prefer-lowest", "" ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '${{ matrix.php-version }}'
-          coverage: '${{ matrix.coverage }}'
+          php-version: ${{ matrix.php-version }}
+          coverage: ${{ matrix.coverage }}
           tools: composer
           extensions: ast
 
@@ -58,18 +61,19 @@ jobs:
         run: make test --no-print-directory
 
       - name: Uploading coverage to coveralls
-        if: "${{ matrix.coverage == 'xdebug' }}"
+        if: '${{ matrix.coverage == ''xdebug'' }}'
         continue-on-error: true
         env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make report-coveralls --no-print-directory || true
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: PHPUnit - ${{ matrix.php-version }} - ${{ matrix.coverage }}
           path: build/
+          overwrite: true
 
 
   linters:
@@ -77,17 +81,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.2, 8.3, 8.4 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '${{ matrix.php-version }}'
+          php-version: ${{ matrix.php-version }}
           coverage: none
           tools: composer
           extensions: ast
@@ -99,11 +103,12 @@ jobs:
         run: make codestyle --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: Linters - ${{ matrix.php-version }}
           path: build/
+          overwrite: true
 
 
   report:
@@ -111,10 +116,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.2, 8.3, 8.4 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -133,8 +138,9 @@ jobs:
         run: make report-all --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: Reports - ${{ matrix.php-version }}
           path: build/
+          overwrite: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This project uses a Makefile with commands from `jbzoo/toolbox-dev`. The primary
 - `make test-all` - Run both tests and code style checks
 - `make report-all` - Generate comprehensive reports (coverage, metrics, etc.)
 
-The project requires PHP 8.2+ and uses `jbzoo/toolbox-dev` for development tooling.
+The project requires PHP 8.3+ and uses `jbzoo/toolbox-dev` for development tooling.
 
 ## Architecture Overview
 
@@ -52,7 +52,7 @@ retry($callback, $maxAttempts, $strategy, $waitCap, $useJitter);
 - PHPUnit tests in `tests/` directory
 - Strategy-specific tests in `tests/Strategies/`
 - Package integration tests and alias compatibility tests
-- CI runs tests on PHP 8.2, 8.3, 8.4 with both `--prefer-lowest` and latest dependencies
+- CI runs tests on PHP 8.3, 8.4, 8.5 with both `--prefer-lowest` and latest dependencies
 
 ### Development Notes
 - Project enforces strict typing (`declare(strict_types=1)`)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 # JBZoo / Retry
 
-[![CI](https://github.com/JBZoo/Retry/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Retry/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Retry/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Retry?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Retry/coverage.svg)](https://shepherd.dev/github/JBZoo/Retry)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Retry/level.svg)](https://shepherd.dev/github/JBZoo/Retry)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/retry/badge)](https://www.codefactor.io/repository/github/jbzoo/retry/issues)
-[![Stable Version](https://poser.pugx.org/jbzoo/retry/version)](https://packagist.org/packages/jbzoo/retry/)    [![Total Downloads](https://poser.pugx.org/jbzoo/retry/downloads)](https://packagist.org/packages/jbzoo/retry/stats)    [![Dependents](https://poser.pugx.org/jbzoo/retry/dependents)](https://packagist.org/packages/jbzoo/retry/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/retry)](https://github.com/JBZoo/Retry/blob/master/LICENSE)
+[![CI](https://github.com/JBZoo/Retry/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Retry/actions/workflows/main.yml?query=branch%3Amaster)
+[![Coverage Status](https://coveralls.io/repos/github/JBZoo/Retry/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Retry?branch=master)
+[![Psalm Coverage](https://shepherd.dev/github/JBZoo/Retry/coverage.svg)](https://shepherd.dev/github/JBZoo/Retry)
+[![Psalm Level](https://shepherd.dev/github/JBZoo/Retry/level.svg)](https://shepherd.dev/github/JBZoo/Retry)
+[![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/retry/badge)](https://www.codefactor.io/repository/github/jbzoo/retry/issues)
+
+[![Stable Version](https://poser.pugx.org/jbzoo/retry/version)](https://packagist.org/packages/jbzoo/retry/)
+[![Total Downloads](https://poser.pugx.org/jbzoo/retry/downloads)](https://packagist.org/packages/jbzoo/retry/stats)
+[![Dependents](https://poser.pugx.org/jbzoo/retry/dependents)](https://packagist.org/packages/jbzoo/retry/dependents?order_by=downloads)
+[![GitHub License](https://img.shields.io/github/license/jbzoo/retry)](https://github.com/JBZoo/Retry/blob/master/LICENSE)
 
 Tiny PHP library providing retry functionality with multiple backoff strategies and jitter support.
 
@@ -16,7 +24,7 @@ Tiny PHP library providing retry functionality with multiple backoff strategies 
 
 ## Requirements
 
-- PHP 8.2 or higher
+- PHP 8.3 or higher
 
 ## About This Fork
 

--- a/composer.json
+++ b/composer.json
@@ -33,11 +33,11 @@
     "prefer-stable"     : true,
 
     "require"           : {
-        "php" : "^8.2"
+        "php" : "^8.3"
     },
 
     "require-dev"       : {
-        "jbzoo/toolbox-dev" : "^7.2"
+        "jbzoo/toolbox-dev" : "^8.0"
     },
 
     "replace"           : {
@@ -63,7 +63,7 @@
 
     "extra"             : {
         "branch-alias" : {
-            "dev-master" : "7.x-dev"
+            "dev-master" : "8.x-dev"
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,25 +10,15 @@
     @copyright  Copyright (C) JBZoo.com, All rights reserved.
     @see        https://github.com/JBZoo/Retry
 -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="tests/autoload.php"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         convertDeprecationsToExceptions="true"
+<phpunit bootstrap="tests/autoload.php"
          executionOrder="random"
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"
          stopOnIncomplete="false"
          stopOnSkipped="false"
-         stopOnRisky="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
->
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
+         stopOnRisky="false">
+    <coverage>
         <report>
             <clover outputFile="build/coverage_xml/main.xml"/>
             <php outputFile="build/coverage_cov/main.cov"/>
@@ -45,4 +35,10 @@
     <logging>
         <junit outputFile="build/coverage_junit/main.xml"/>
     </logging>
+
+    <source>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/Strategies/AbstractStrategy.php
+++ b/src/Strategies/AbstractStrategy.php
@@ -18,11 +18,8 @@ namespace JBZoo\Retry\Strategies;
 
 abstract class AbstractStrategy
 {
-    /**
-     * Base wait time in ms.
-     * @var int
-     */
-    protected const DEFAULT_BASE = 100;
+    /** Base wait time in ms. */
+    protected const int DEFAULT_BASE = 100;
 
     /** @var int */
     protected $base;


### PR DESCRIPTION
Coordinated ecosystem-wide **8.0** major (packaging-driven).

- Minimum PHP raised to **8.3** (CI: 8.3 / 8.4 / 8.5).
- All inter-package `jbzoo/*` deps → `^8.0`.

### Changed (BC)
- Public constant `AbstractStrategy::DEFAULT_BASE` is now typed — an external subclass overriding it must declare a compatible type.
